### PR TITLE
Fix Go dependency vulnerabilities and modernize GitHub Actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,22 +4,24 @@ on:
   push:
     tags:
       - v*.*.*
+permissions:
+  contents: write
 jobs:
   release:
     name: Release nature-remo-cli
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.16"
+          go-version-file: go.mod
       - name: Run goreleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7.1.0
         env:
           GO111MODULE: on
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         with:
-          version: latest
+          version: '~> v1'
           args: release --rm-dist

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,27 +7,25 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   test:
     name: Test nature-remo-cli
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.16.0"
+          go-version-file: go.mod
       - name: Run Unit tests
         env:
           GO111MODULE: on
         run: |
           make test-coverage
-      - name: Install goveralls
-        env:
-          GO111MODULE: off
-        run: go get github.com/mattn/goveralls
       - name: Send coverage
-        uses: shogo82148/actions-goveralls@v1
+        uses: shogo82148/actions-goveralls@9606dbc5ac5cf888a0e9ef901515c3cd516a2790 # v1.11.0
         with:
           path-to-profile: covprofile

--- a/configfile/configfile_test.go
+++ b/configfile/configfile_test.go
@@ -44,19 +44,19 @@ var (
 func TestNew(t *testing.T) {
 	_, err := New(testFilePath)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err)
 	}
 }
 
 func TestLoadToken(t *testing.T) {
 	config, err := New(testFilePath)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	}
 
 	gottenToken, err := config.LoadToken()
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	}
 	if gottenToken != expectedToken {
 		t.Errorf("want: %s\nget : %s", expectedToken, gottenToken)
@@ -66,12 +66,12 @@ func TestLoadToken(t *testing.T) {
 func TestLoadAppliances(t *testing.T) {
 	config, err := New(testFilePath)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	}
 
 	gottenAppliances, err := config.LoadAppliances()
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(gottenAppliances, expectedAppliances) {
 		t.Errorf("want: %v\nget : %v", expectedAppliances, gottenAppliances)
@@ -83,12 +83,12 @@ func TestLoadAllSetting(t *testing.T) {
 
 	config, err := New(testFilePath)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	}
 
 	gottenSetting, err := config.LoadAllSetting()
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(gottenSetting, expectedSetting) {
 		t.Errorf("want: %v\nget : %v", expectedSetting, gottenSetting)
@@ -100,7 +100,7 @@ func TestGetConfigFilePath(t *testing.T) {
 
 	gotten, err := GetConfigFilePath()
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	}
 	if gotten != expected {
 		t.Errorf("want: %s\nget : %s", expected, gotten)

--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,25 @@
 module github.com/chroju/nature-remo-cli
 
-go 1.12
+go 1.25.0
 
 require (
-	github.com/armon/go-radix v1.0.0 // indirect
-	github.com/mattn/go-isatty v0.0.4 // indirect
-	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/mitchellh/cli v1.0.0
 	github.com/olekukonko/tablewriter v0.0.1
 	github.com/pkg/errors v0.8.0
-	github.com/posener/complete v1.2.0 // indirect
 	github.com/spf13/pflag v1.0.3
 	github.com/tenntenn/natureremo v0.0.1
-	golang.org/x/sys v0.0.0-20181019160139-8e24a49d80f8 // indirect
-	gopkg.in/yaml.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/armon/go-radix v1.0.0 // indirect
+	github.com/bgentry/speakeasy v0.1.0 // indirect
+	github.com/fatih/color v1.7.0 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.0.0 // indirect
+	github.com/mattn/go-colorable v0.0.9 // indirect
+	github.com/mattn/go-isatty v0.0.4 // indirect
+	github.com/mattn/go-runewidth v0.0.4 // indirect
+	github.com/posener/complete v1.2.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -30,9 +30,9 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/tenntenn/natureremo v0.0.1 h1:Ncv4T12rmSqUIQ2MddZbWGwbbMDea1UURU1CjSqH/wM=
 github.com/tenntenn/natureremo v0.0.1/go.mod h1:yjrSzQ3xhCaU29aHk5TqouGL6PCjUB7my5/f1J8qVwM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20181019160139-8e24a49d80f8 h1:R91KX5nmbbvEd7w370cbVzKC+EzCTGqZq63Zad5IcLM=
-golang.org/x/sys v0.0.0-20181019160139-8e24a49d80f8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
## Summary

### Dependencies (Dependabot alerts)
- Update `gopkg.in/yaml.v2` v2.2.2 -> v2.4.0 (high severity DoS, fixed in >= 2.2.4, plus medium alerts)
- Update `golang.org/x/sys` -> v0.46.0 (medium severity)
- Bump the `go` directive to 1.25.0, required by `golang.org/x/sys` v0.46.0
- Adapt `configfile` tests to the vet printf check enforced since Go 1.24 (`t.Errorf(err.Error())` -> `t.Error(err)`)

Verified locally with `go build ./...` and `go test ./...` (all passing).

### CI workflows
- SHA-pin all actions and update to current versions:
  - `actions/checkout@master` -> v6.0.2
  - `actions/setup-go` v1/v2 (deprecated node12 runtime) -> v6.4.0, now using `go-version-file: go.mod`
  - `goreleaser/goreleaser-action` v2 -> v7.1.0 with `version: '~> v1'`, since `.goreleaser.yaml` still uses goreleaser v1 syntax (`brews[].tap` etc.) — config migration is out of scope for this PR
  - `shogo82148/actions-goveralls` v1 -> v1.11.0
- Remove the manual goveralls install step (GOPATH-mode `go get` was removed in Go 1.22; the goveralls action ships its own binary)
- Replace the retired `ubuntu-20.04` runner with `ubuntu-latest`
- Add least-privilege `permissions:` (`contents: read` for test, `contents: write` for release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)